### PR TITLE
Ignore the test directory for publishing and node_modules for git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
   ],
   "license": "BSD-3-Clause",
   "main": "index.js",
+  "files": [
+    "index.js"
+  ],
   "repository": {
     "type": "git",
     "url": "git://github.com/feross/ieee754.git"


### PR DESCRIPTION
Eliminate the `test` directory being included in the published package by adding a `files` property in the `package.json`. npm will include the README, LICENSE, and package.json as well.

Added a `.gitignore` file with `node_modules` in it so it would stop complaining about that untracked directory.