### PR TITLE
index.d.tx: buffer can be ArrayLike<number>, and make sure it works in tests

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,10 +1,10 @@
 declare namespace ieee754 {
     export function read(
-        buffer: Uint8Array, offset: number, isLE: boolean, mLen: number,
+        buffer: ArrayLike<number>, offset: number, isLE: boolean, mLen: number,
         nBytes: number): number;
     export function write(
-        buffer: Uint8Array, value: number, offset: number, isLE: boolean,
+        buffer: ArrayLike<number>, value: number, offset: number, isLE: boolean,
         mLen: number, nBytes: number): void;
   }
-  
+
   export = ieee754;

--- a/test/basic.js
+++ b/test/basic.js
@@ -3,46 +3,68 @@ const test = require('tape')
 
 const EPSILON = 0.00001
 
-test('read float', function (t) {
-  const val = 42.42
-  const buf = Buffer.alloc(4)
+const bufferAllocators = [
+  function createBuffer (n) {
+    return Buffer.alloc(n)
+  },
+  function createArray (n) {
+    return new Array(n)
+  }
+]
+for (const allocateBuffer of bufferAllocators) {
+  test(allocateBuffer.name, function (t) {
+    t.test('read float', function (t) {
+      const val = 42.42
+      const buffer = Buffer.alloc(4)
+      buffer.writeFloatLE(val, 0)
 
-  buf.writeFloatLE(val, 0)
-  const num = ieee754.read(buf, 0, true, 23, 4)
+      const buf = allocateBuffer(4)
+      for (let i = 0; i < buffer.length; i++) {
+        buf[i] = buffer[i]
+      }
 
-  t.ok(Math.abs(num - val) < EPSILON)
-  t.end()
-})
+      const num = ieee754.read(buf, 0, true, 23, 4)
 
-test('write float', function (t) {
-  const val = 42.42
-  const buf = Buffer.alloc(4)
+      t.ok(Math.abs(num - val) < EPSILON)
+      t.end()
+    })
 
-  ieee754.write(buf, val, 0, true, 23, 4)
-  const num = buf.readFloatLE(0)
+    t.test('write float', function (t) {
+      const val = 42.42
+      const buf = allocateBuffer(4)
 
-  t.ok(Math.abs(num - val) < EPSILON)
-  t.end()
-})
+      ieee754.write(buf, val, 0, true, 23, 4)
+      const num = Buffer.from(buf).readFloatLE(0)
 
-test('read double', function (t) {
-  const value = 12345.123456789
-  const buf = Buffer.alloc(8)
+      t.ok(Math.abs(num - val) < EPSILON)
+      t.end()
+    })
 
-  buf.writeDoubleLE(value, 0)
-  const num = ieee754.read(buf, 0, true, 52, 8)
+    t.test('read double', function (t) {
+      const value = 12345.123456789
+      const buffer = Buffer.alloc(8)
+      buffer.writeDoubleLE(value, 0)
 
-  t.ok(Math.abs(num - value) < EPSILON)
-  t.end()
-})
+      const buf = allocateBuffer(8)
+      for (let i = 0; i < buffer.length; i++) {
+        buf[i] = buffer[i]
+      }
 
-test('write double', function (t) {
-  const value = 12345.123456789
-  const buf = Buffer.alloc(8)
+      const num = ieee754.read(buf, 0, true, 52, 8)
 
-  ieee754.write(buf, value, 0, true, 52, 8)
-  const num = buf.readDoubleLE(0)
+      t.ok(Math.abs(num - value) < EPSILON)
+      t.end()
+    })
 
-  t.ok(Math.abs(num - value) < EPSILON)
-  t.end()
-})
+    t.test('write double', function (t) {
+      const value = 12345.123456789
+      const buf = allocateBuffer(8)
+
+      ieee754.write(buf, value, 0, true, 52, 8)
+      const num = Buffer.from(buf).readDoubleLE(0)
+
+      t.ok(Math.abs(num - value) < EPSILON)
+      t.end()
+    })
+  })
+}


### PR DESCRIPTION
`index.d.ts` declares `buffer` is `Uint8Array`, but in fact it can be `Array<number>` or any kind of array-like object (`ArrayLike<number>` in TypeScript), so I've tweaked those declarations in `index.d.ts` and add tests to use `Array` as well as `Buffer`. 

